### PR TITLE
Switch license to CC BY-SA 4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,5 @@
-MIT License
+Creative Commons Attribution-ShareAlike 4.0 International Public License
 
-Copyright (c) 2025, Alexander Panchin and Nullianism Contributors
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution‑ShareAlike 4.0 International Public License ("Public License").
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Full text: https://creativecommons.org/licenses/by-sa/4.0/legalcode


### PR DESCRIPTION

## ✨ What’s changed

- Removed `LICENSE-MIT` (MIT)
- Added `LICENSE` containing the full text of Creative Commons Attribution-ShareAlike 4.0 International

## 📚 Motivation & Context

Nullianism defines itself as an open-source religion — not just in form, but in values.  
The MIT license, while permissive and common in software, allows proprietary forks of philosophical content, private commercialization, and potentially misleading derivatives.  
This contradicts our doctrine’s ethical principles:

- **Knowledge is a moral duty.**
- **Curiosity should remain freely accessible.**
- **Cultural evolution must stay decentralized and transparent.**

Creative Commons Attribution-ShareAlike 4.0 (CC BY-SA) ensures that:

- All adaptations of our texts remain open and attributed.
- Derivative works contribute back to the commons.
- The philosophy of Nullianism evolves collectively and ethically.

This license aligns with other knowledge-sharing ecosystems (e.g., Wikipedia) and is legally appropriate for manifestos, rituals, and non-code doctrine.

## ⚠️ Breaking changes

All contributors must accept CC BY-SA 4.0 for their existing contributions.  